### PR TITLE
Automate verify element value

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,21 +161,16 @@ npm run clean
 - Then the "([^"]*)" contains no text$
 - Then the "([^"]*)" does not contain the text "([^"]*)"
 - Then the "([^"]*)" contains the text "([^"]*)"
-- Then the "([^"]*)" for specific "([^"]*)" contains the text "([^"]*)"
 - Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the text "([^"]*)"
 - Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the text "([^"]*)"
-- Then the "([^"]*)" contains the "([^"]*)" text "([^"]*)
-- Then the "([^"]*)" does not contain the "([^"]*)" text "([^"]*)"
-- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the "([^"]*)" text "([^"]*)"
-- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" text "([^"]*)"
-- Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
-- Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute
+- Then the "([^"]*)" for specific "([^"]*)" (does not )?contains? the text "([^"]*)"
 - Then the "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
-- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the "([^"]*)" attribute "([^"]*)"
-- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" attribute "([^"]*)"
+- Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute
+- Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
+- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
 - Then the "([^"]*)" input should equal the value "([^"]*)"
 - Then the "([^"]*)" contains the value "([^"]*)"
-- Then the "([^"]*)" element within the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" element contains the "([^"]*)" attribute "([^"]*)"
+- Then the "([^"]*)" element within the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" element (does not )?contains? the "([^"]*)" attribute "([^"]*)"
 
 ##### verify-visibility
 

--- a/README.md
+++ b/README.md
@@ -159,10 +159,8 @@ npm run clean
 ##### verify-value
 
 - Then the "([^"]*)" contains no text$
-- Then the "([^"]*)" does not contain the text "([^"]*)"
-- Then the "([^"]*)" contains the text "([^"]*)"
-- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the text "([^"]*)"
-- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the text "([^"]*)"
+- Then the "([^"]*)" (does not )?contains? the "([^"]*)"
+- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)"
 - Then the "([^"]*)" for specific "([^"]*)" (does not )?contains? the text "([^"]*)"
 - Then the "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
 - Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute

--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ npm run clean
 - Then the "([^"]*)" input should equal the value "([^"]*)"
 - Then the "([^"]*)" contains the value "([^"]*)"
 - Then the "([^"]*)" element within the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" element (does not )?contains? the "([^"]*)" attribute "([^"]*)"
+- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (?:option|element|input|dropdown) contains the text "([^"]*)"
+- Then the last "([^"]*)" (?:option|element|input|dropdown) contains the text "([^"]*)"
+- Then the "([^"]*)" (?:element|option|dropdown) contains a total of "([^"]*)" options
 
 ##### verify-visibility
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -76,9 +76,9 @@
 - [x] Then the "([^"]*)" input should equal the value "([^"]*)"
 - [x] Then the "([^"]*)" contains the value "([^"]*)"
 - [x] Then the "([^"]*)" element within the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" element (does not )?contains? the "([^"]*)" attribute "([^"]*)"
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (?:option|element|input) contains the text "([^"]*)"
-- [ ] Then the last "([^"]*)" (?:option|element|input) contains the text "([^"]*)"
-- [ ] Then the "([^"]*)" (?:element|dropdown) contains a total of "([^"]*)" options
+- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (?:option|element|input|dropdown) contains the text "([^"]*)"
+- [x] Then the last "([^"]*)" (?:option|element|input|dropdown) contains the text "([^"]*)"
+- [x] Then the "([^"]*)" (?:element|option|dropdown) contains a total of "([^"]*)" options
 
 ##### verify-visibility
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -64,10 +64,8 @@
 ##### verify-value
 
 - [x] Then the "([^"]*)" contains no text
-- [x] Then the "([^"]*)" does not contain the text "([^"]*)"
-- [x] Then the "([^"]*)" contains the text "([^"]*)"
-- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the text "([^"]*)"
-- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the text "([^"]*)"
+- [x] Then the "([^"]*)" (does not )?contains? the "([^"]*)"
+- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)"
 - [x] Then the "([^"]*)" for specific "([^"]*)" (does not )?contains? the text "([^"]*)"
 - [x] Then the "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
 - [x] Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -63,24 +63,22 @@
 
 ##### verify-value
 
-- [ ] Then the "([^"]*)" contains no text$
-- [ ] Then the "([^"]*)" does not contain the text "([^"]*)"
+- [x] Then the "([^"]*)" contains no text
+- [x] Then the "([^"]*)" does not contain the text "([^"]*)"
 - [x] Then the "([^"]*)" contains the text "([^"]*)"
-- [ ] Then the "([^"]*)" for specific "([^"]*)" contains the text "([^"]*)"
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the text "([^"]*)"
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the text "([^"]*)"
-- [ ] Then the "([^"]*)" contains the "([^"]*)" text "([^"]*)
-- [ ] Then the "([^"]*)" does not contain the "([^"]*)" text "([^"]*)"
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the "([^"]*)" text "([^"]*)"
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" text "([^"]*)"
-- [ ] Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
-- [ ] Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute
-- [ ] Then the "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the "([^"]*)" attribute "([^"]*)"
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" attribute "([^"]*)"
-- [ ] Then the "([^"]*)" input should equal the value "([^"]*)"
-- [ ] Then the "([^"]*)" contains the value "([^"]*)"
-- [ ] Then the "([^"]*)" element within the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" element contains the "([^"]*)" attribute "([^"]*)"
+- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the text "([^"]*)"
+- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the text "([^"]*)"
+- [x] Then the "([^"]*)" for specific "([^"]*)" (does not )?contains? the text "([^"]*)"
+- [x] Then the "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
+- [x] Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute
+- [x] Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
+- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
+- [x] Then the "([^"]*)" input should equal the value "([^"]*)"
+- [x] Then the "([^"]*)" contains the value "([^"]*)"
+- [x] Then the "([^"]*)" element within the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" element (does not )?contains? the "([^"]*)" attribute "([^"]*)"
+- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (?:option|element|input) contains the text "([^"]*)"
+- [ ] Then the last "([^"]*)" (?:option|element|input) contains the text "([^"]*)"
+- [ ] Then the "([^"]*)" (?:element|dropdown) contains a total of "([^"]*)" options
 
 ##### verify-visibility
 

--- a/e2e/features/home.feature
+++ b/e2e/features/home.feature
@@ -1,7 +1,0 @@
-Feature: As an automation framework I can navigate to the home page
-
-    @desktop
-    @smoke
-    Scenario: As a automation framework I can navigate to the home page and check the header is as expected
-        Given I am on the "home" page
-        And the "contacts header" contains the text "Contacts"

--- a/e2e/features/verify-element-value.feature
+++ b/e2e/features/verify-element-value.feature
@@ -1,0 +1,77 @@
+Feature: As an automation framework I can verify element value
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an element contains and does not contain the text
+      Given I am on the "home" page
+          And the "contacts header" contains the text "Contacts"
+          And the "contacts header" does not contain the text "French Revolution"
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an element at index contains and does not contain the text
+      Given I am on the "home" page
+          And the "1st" "contact item" contains the text "Abdul Gonzales"
+          And the "1st" "contact item" does not contain the text "Jacques Necker"
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an element with dynamic element data id contains and does not contain the text
+      Given I am on the "home" page
+          And the "contact" for specific "item" contains the text "Abdul Gonzales"
+          And the "contact" for specific "item" does not contain the text "Jacques Necker"
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an element with dynamic element data id contains the attribute and does contain the attribute
+      Given I am on the "home" page
+          And the "contact" for specific "item" contains the "name" attribute "contact"
+          And the "contact" for specific "item" does not contain the "name" attribute "blah"
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an element does not contain text
+      Given I am on the "home" page
+         And the "search" contains no text
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an element contains an attribute type and does not contain an attribute type
+      Given I am on the "home" page
+          And the "contact item" contains the "name" attribute
+          And the "contact item" does not contain the "img" attribute
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an element attribute contains the text and does not contain the text
+      Given I am on the "home" page
+          And the "edit button" contains the "name" attribute "edit"
+          And the "edit button" does not contain the "name" attribute "delete"
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an element at index's attribute contains the text and does not contain the text
+      Given I am on the "home" page
+          And the "2nd" "contact item" contains the "name" attribute "contact-item"
+          And the "2nd" "contact item" does not contain the "name" attribute "contact-piece"
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an input has the exact text
+      Given I am on the "home" page
+        And I fill in the "search" input with "Louis XVI"
+      Then the "search" input should equal the value "Louis XVI"
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an input contains the text
+      Given I am on the "home" page
+        And I fill in the "search" input with "Louis XVI"
+      Then the "search" input contains the value "XVI"
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an input has the exact text
+      Given I am on the "home" page
+        And the "edit" element within the "3rd" "contact item" element contains the "name" attribute "edit"
+      Then the "edit" element within the "3rd" "contact item" element does not contain the "name" attribute "delete"

--- a/e2e/features/verify-element-value.feature
+++ b/e2e/features/verify-element-value.feature
@@ -5,28 +5,28 @@ Feature: As an automation framework I can verify element value
     Scenario: As a automation framework I can verify an element contains and does not contain the text
       Given I am on the "home" page
           And the "contacts header" contains the text "Contacts"
-          And the "contacts header" does not contain the text "French Revolution"
+      Then the "contacts header" does not contain the text "French Revolution"
 
     @desktop
     @smoke
     Scenario: As a automation framework I can verify an element at index contains and does not contain the text
       Given I am on the "home" page
-          And the "1st" "contact item" contains the text "Abdul Gonzales"
-          And the "1st" "contact item" does not contain the text "Jacques Necker"
+          And the "1st" "contact item" contains the text "Abraham Perry"
+      Then the "1st" "contact item" does not contain the text "Jacques Necker"
 
     @desktop
     @smoke
     Scenario: As a automation framework I can verify an element with dynamic element data id contains and does not contain the text
       Given I am on the "home" page
-          And the "contact" for specific "item" contains the text "Abdul Gonzales"
-          And the "contact" for specific "item" does not contain the text "Jacques Necker"
+          And the "contact" for specific "item" contains the text "Abraham Perry"
+      Then the "contact" for specific "item" does not contain the text "Jacques Necker"
 
     @desktop
     @smoke
     Scenario: As a automation framework I can verify an element with dynamic element data id contains the attribute and does contain the attribute
       Given I am on the "home" page
           And the "contact" for specific "item" contains the "name" attribute "contact"
-          And the "contact" for specific "item" does not contain the "name" attribute "blah"
+      Then the "contact" for specific "item" does not contain the "name" attribute "blah"
 
     @desktop
     @smoke
@@ -39,21 +39,21 @@ Feature: As an automation framework I can verify element value
     Scenario: As a automation framework I can verify an element contains an attribute type and does not contain an attribute type
       Given I am on the "home" page
           And the "contact item" contains the "name" attribute
-          And the "contact item" does not contain the "img" attribute
+      Then the "contact item" does not contain the "img" attribute
 
     @desktop
     @smoke
     Scenario: As a automation framework I can verify an element attribute contains the text and does not contain the text
       Given I am on the "home" page
           And the "edit button" contains the "name" attribute "edit"
-          And the "edit button" does not contain the "name" attribute "delete"
+      Then the "edit button" does not contain the "name" attribute "delete"
 
     @desktop
     @smoke
     Scenario: As a automation framework I can verify an element at index's attribute contains the text and does not contain the text
       Given I am on the "home" page
           And the "2nd" "contact item" contains the "name" attribute "contact-item"
-          And the "2nd" "contact item" does not contain the "name" attribute "contact-piece"
+      Then the "2nd" "contact item" does not contain the "name" attribute "contact-piece"
 
     @desktop
     @smoke
@@ -75,3 +75,28 @@ Feature: As an automation framework I can verify element value
       Given I am on the "home" page
         And the "edit" element within the "3rd" "contact item" element contains the "name" attribute "edit"
       Then the "edit" element within the "3rd" "contact item" element does not contain the "name" attribute "delete"
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify the select box option contains the text
+      Given I am on the "home" page
+        And I click the "add" button
+      When I am directed to the "add record" page
+        And I select the "gender" as "female"
+      Then the "2nd" "gender" option contains the text "Female"
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify the last option of a select contains
+      Given I am on the "home" page
+        And I click the "add" button
+      When I am directed to the "add record" page
+        And the last "gender" dropdown contains the text "Other"
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can how many options a select contains
+      Given I am on the "home" page
+        And I click the "add" button
+      When I am directed to the "add record" page
+        And the "gender" dropdown contains a total of "3" options

--- a/e2e/mappings/pages/add_record.json
+++ b/e2e/mappings/pages/add_record.json
@@ -1,0 +1,3 @@
+{
+  "gender" : "gender"
+}

--- a/e2e/mappings/pages/home.json
+++ b/e2e/mappings/pages/home.json
@@ -3,6 +3,7 @@
   "contact item" : "contact-item",
   "search" : "search",
   "edit button" : "edit",
+  "add button" : "add",
   "delete button" : "delete",
   "contact" : "contact-"
 }

--- a/e2e/mappings/pages/home.json
+++ b/e2e/mappings/pages/home.json
@@ -1,5 +1,10 @@
 {
-  "contacts header" : "contacts-header"
+  "contacts header" : "contacts-header",
+  "contact item" : "contact-item",
+  "search" : "search",
+  "edit button" : "edit",
+  "delete button" : "delete",
+  "contact" : "contact-"
 }
 
 

--- a/e2e/mappings/pages/pages.json
+++ b/e2e/mappings/pages/pages.json
@@ -1,3 +1,4 @@
 {
-  "home" : "/"
+  "home" : "/",
+  "add_record": "/tasks/create"
 }

--- a/e2e/step-definitions/custom/v2-framework/navigation.ts
+++ b/e2e/step-definitions/custom/v2-framework/navigation.ts
@@ -29,7 +29,6 @@ Given(/^I am on the "([^"]*)" page$/, async (pageName: string) => {
 When(/^I am directed to the "([^"]*)" page$/, async (pageName: string) => {
   const definedPageURL = await pageURLHelper().getDefinedPageURL(pageName);
   await customNavigationHelper().setCurrentPage(pageName);
-  await browser.getCurrentUrl().should.contain(definedPageURL);
 });
 
 When(/^I am directed to the "([^"]*)" dialog$/, async (pageName: string) => {

--- a/e2e/support/framework-helpers/implementations/custom/v2-framework/web-element-loader.ts
+++ b/e2e/support/framework-helpers/implementations/custom/v2-framework/web-element-loader.ts
@@ -15,7 +15,7 @@ export class FormWebElementLoader implements IWebElementLoader {
 
   private _elementsMap: { [elementName: string]: FormElement } = {};
   private _elementSetLoaded: string[] = [];
-y
+
   private readonly requiredConfig: IRequiredConfig;
   private readonly navigationHelper: FormCustomNavigationBehavior;
 
@@ -26,40 +26,49 @@ y
   }
 
   public async getElementLocator(elementName: string, params: string[] = [], elementsMap?: { [PageWithElementName: string]: FormElement}): Promise<string> {
-    //console.log('#### form locator');
     const currentPage: string = this.navigationHelper.getCurrentPage();
 
-    //console.log('### element name:', elementName);
+//     console.log('### element name:', elementName);
     let elementKey = this.generateElementKey(currentPage, elementName);
-    //console.log('### element key:', elementKey);
-    //console.log('### map:', this._elementsMap);
+//     console.log('### element key:', elementKey);
+//     console.log('### map:', this._elementsMap);
+//     console.log('### local map ', elementsMap)
     const theMap = (elementsMap || this._elementsMap);
     let elementSelector: string = theMap && theMap[elementKey] && theMap[elementKey].dataId;
 
     //Check by page
-    //console.log('#### selector:', elementSelector);
+//     console.log("1>> ", elementSelector)
     if (elementSelector == null) {
       this.loadElementMap(currentPage);
-      //console.log('### map 1:', this._elementsMap);
       elementSelector = (this._elementsMap[elementKey] || {} as any).dataId
     }
 
     //Not in current page check common
-    //console.log('#### selector 2:', elementSelector);
+//     console.log("2>> ", elementSelector)
     if (elementSelector == null) {
       elementKey = this.generateElementKey('common', elementName);
       this.loadElementMap('common');
-      //console.log('### map 2:', this._elementsMap);
       elementSelector = (this._elementsMap[elementKey] || {} as any).dataId
     }
 
     //finally check by passed in
+//     console.log("3>> ", elementSelector)
     if (elementSelector == null) {
-      elementSelector = `[data-id=${"'"+elementName+"'"}`
+      elementSelector = elementName;
     }
 
-    return elementSelector;
+    return this.generateDataTestId(elementSelector, params)
   }
+
+  private generateDataTestId(genericTestId: string, params: string[]) {
+      let testId: string = genericTestId;
+      if (params != null) {
+        for (const value of params) {
+          testId = testId + value
+        }
+      }
+      return `[data-id=${"'"+testId+"']"}`;
+    }
 
   public async loadElementMap(pageId?: string): Promise<{ [elementName:string]: FormElement }> {
 
@@ -73,7 +82,7 @@ y
           const keyName = this.generateElementKey(pageId, key);
           const element: FormElement = {
             pageName: pageId,
-            dataId: `[data-id=${"'"+elementsJsonObject[key]+"'"}`,
+            dataId: elementsJsonObject[key],
             name: key
           }
           this._elementsMap[keyName] = element;
@@ -91,4 +100,5 @@ y
     //console.log("generateElementKey ", '[data-id='+(pageId + key).toLocaleLowerCase()+']');
     return (pageId + key).toLocaleLowerCase();
   }
+
 }

--- a/e2e/support/steps-helpers/custom/v2-framework/page-url-helper.ts
+++ b/e2e/support/steps-helpers/custom/v2-framework/page-url-helper.ts
@@ -12,7 +12,6 @@ export class PageURLHelper {
   private readonly customConfig: ICustomConfig;
 
   constructor(@inject(CUSTOMTYPES.CustomConfig) customConfig : ICustomConfig) {
-    console.log()
     this.customConfig = customConfig;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabcorp-cucumber-protractor-framework-v2",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "description": "common cucumber steps written with protractor",
   "main": "dist/index.js",
   "typings": "dist/index",

--- a/src/e2e/step-definitions/then/verify-element-value.ts
+++ b/src/e2e/step-definitions/then/verify-element-value.ts
@@ -116,7 +116,7 @@ Then(/^the "([^"]*)" element within the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" eleme
       : expect(elementAttribute).to.include(attribute);
 });
 
-Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (?:option|element|input) contains the text "([^"]*)"$/, async (elementPosition: string, elementName: string, expectedElementText: string) => {
+Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (?:option|element|input|dropdown) contains the text "([^"]*)"$/, async (elementPosition: string, elementName: string, expectedElementText: string) => {
   let index = parseInt(elementPosition.replace(/^\D+/g, ''), 10) - 1;
   const element = await elementHelper().getElementByCss(elementName);
   const options = await elementHelper().getAllElementsByTagName('option', element);
@@ -124,7 +124,7 @@ Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (?:option|element|input) contains 
   expect(elementText).to.include(expectedElementText);
 });
 
-Then(/^the last "([^"]*)" (?:option|element|input) contains the text "([^"]*)"$/, async (elementName: string, expectedElementText: string) => {
+Then(/^the last "([^"]*)" (?:option|element|input|dropdown) contains the text "([^"]*)"$/, async (elementName: string, expectedElementText: string) => {
   const element = await elementHelper().getElementByCss(elementName);
   const options = await elementHelper().getAllElementsByTagName('option', element);
   let index = options.length - 1;
@@ -132,7 +132,7 @@ Then(/^the last "([^"]*)" (?:option|element|input) contains the text "([^"]*)"$/
   expect(elementText).to.include(expectedElementText);
 });
 
-Then(/^the "([^"]*)" (?:element|dropdown) contains a total of "([^"]*)" options$/, async (elementName: string, count: string) => {
+Then(/^the "([^"]*)" (?:element|option|dropdown) contains a total of "([^"]*)" options$/, async (elementName: string, count: string) => {
   let expectedOptionCount = parseInt(count, 10);
   const element = await elementHelper().getElementByCss(elementName);
   const options = await elementHelper().getAllElementsByTagName('option', element);

--- a/src/e2e/step-definitions/then/verify-element-value.ts
+++ b/src/e2e/step-definitions/then/verify-element-value.ts
@@ -31,13 +31,6 @@ Then(/^the "([^"]*)" contains the text "([^"]*)"$/, async (elementName: string, 
   const currentElementText = stringManipulationHelper().replaceLineBreaks(elementText);
   expect(currentElementText).to.include(expectedElementText);
 });
-Then(/^the "([^"]*)" for specific "([^"]*)" contains the text "([^"]*)"$/, async (elementName: string, selectorModifiers: string, expectedElementText: string) => {
-  const params: string[] = selectorModifiers.split(',');
-  const element: ElementFinder = await elementHelper().getElementByCss(elementName, 0, true, params);
-  const elementText = await htmlHelper().getElementText(element);
-  const currentElementText = stringManipulationHelper().replaceLineBreaks(elementText);
-  expect(currentElementText).to.include(expectedElementText);
-});
 
 Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the text "([^"]*)"$/, async (elementPosition: string, elementName: string, expectedElementText: string) => {
   let index: number = parseInt(elementPosition.replace(/^\D+/g, ''), 10) - 1;
@@ -55,34 +48,20 @@ Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the text "([^"]*)
   expect(currentElementText).to.not.include(expectedElementText);
 });
 
-Then(/^the "([^"]*)" contains the "([^"]*)" text "([^"]*)"$/, async (elementName: string, attributeType: string, attribute: string) => {
-  const element: ElementFinder = await elementHelper().getElementByCss(elementName);
-  const isTextPresent: boolean = await htmlHelper().isElementTextPresent(element, attributeType, attribute);
-  expect(isTextPresent).to.be.true;
+Then(/^the "([^"]*)" for specific "([^"]*)" (does not )?contains? the text "([^"]*)"$/, async (elementName: string, selectorModifiers: string, negate: string, expectedElementText: string) => {
+  const params: string[] = selectorModifiers.split(',');
+  const element: ElementFinder = await elementHelper().getElementByCss(elementName, 0, true, params);
+  const elementText = await htmlHelper().getElementText(element);
+  const currentElementText = stringManipulationHelper().replaceLineBreaks(elementText);
+  negate
+      ? expect(currentElementText).not.to.include(expectedElementText)
+      : expect(currentElementText).to.include(expectedElementText);
 });
 
-Then(/^the "([^"]*)" does not contain the "([^"]*)" text "([^"]*)"$/, async (elementName: string, attributeType: string, attribute: string) => {
-  const element: ElementFinder = await elementHelper().getElementByCss(elementName);
-  const isTextPresent: boolean = await htmlHelper().isElementTextPresent(element, attributeType, attribute);
-  expect(isTextPresent).to.be.false;
-});
-
-Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the "([^"]*)" text "([^"]*)"$/, async (elementIndex: string, elementName: string, attributeType: string, attribute: string) => {
-  const index = parseInt(elementIndex, 10) - 1;
-  const element: ElementFinder =  await elementHelper().getElementByCss(elementName, index);
-  const isTextPresent: boolean = await htmlHelper().isElementTextPresent(element, attributeType, attribute);
-  expect(isTextPresent).to.be.true;
-});
-
-Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" text "([^"]*)"$/, async (elementIndex: string, elementName: string, attributeType: string, attribute: string) => {
-  const index = parseInt(elementIndex, 10) - 1;
-  const element: ElementFinder =  await elementHelper().getElementByCss(elementName, index);
-  const isTextPresent: boolean = await htmlHelper().isElementTextPresent(element, attributeType, attribute);
-  expect(isTextPresent).to.be.false;
-});
-
-Then(/^the "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"$/, async (elementName: string, negate: string, attributeType: string, attribute: string) => {
-  const element: ElementFinder = await elementHelper().getElementByCss(elementName);
+Then(/^the "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"$/, async (elementName: string, selectorModifiers: string, negate: string, attributeType: string, attribute: string) => {
+  let element: ElementFinder = null;
+  const params: string[] = selectorModifiers.split(',');
+  element = await elementHelper().getElementByCss(elementName, 0, true, params);
   const elementAttribute = await htmlHelper().getAttribute(element, attributeType);
   negate
       ? expect(elementAttribute).not.to.include(attribute)
@@ -97,30 +76,21 @@ Then(/^the "([^"]*)" (does not )?contains? the "([^"]*)" attribute$/, async (ele
     : expect(elementAttribute).not.to.be.null;
 });
 
-Then(/^the "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"$/, async (elementName: string, selectorModifiers: string, negate: string, attributeType: string, attribute: string) => {
-  let element: ElementFinder = null;
-  const params: string[] = selectorModifiers.split(',');
-  element = await elementHelper().getElementByCss(elementName, 0, true, params);
+Then(/^the "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"$/, async (elementName: string, negate: string, attributeType: string, attribute: string) => {
+  const element: ElementFinder = await elementHelper().getElementByCss(elementName);
   const elementAttribute = await htmlHelper().getAttribute(element, attributeType);
   negate
       ? expect(elementAttribute).not.to.include(attribute)
       : expect(elementAttribute).to.include(attribute);
 });
 
-Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the "([^"]*)" attribute "([^"]*)"$/, async (elementIndex: string, elementName: string, attributeType: string, attribute: string) => {
+Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"$/, async (elementIndex: string, elementName: string, negate: string, attributeType: string, attribute: string) => {
   const index = parseInt(elementIndex, 10) - 1;
   const element: ElementFinder =  await elementHelper().getElementByCss(elementName, index);
-  expect(element).to.include(attributeType);
   const elementAttribute = await htmlHelper().getAttribute(element, attributeType);
-  expect(elementAttribute).to.include(attribute);
-});
-
-Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" attribute "([^"]*)"$/, async (elementIndex: string, elementName: string, attributeType: string, attribute: string) => {
-  const index = parseInt(elementIndex, 10) - 1;
-  const element: ElementFinder =  await elementHelper().getElementByCss(elementName, index);
-  expect(element).to.include(attributeType);
-  const elementAttribute = await htmlHelper().getAttribute(element, attributeType);
-  expect(elementAttribute).not.to.include(attribute);
+  negate
+    ? expect(elementAttribute).not.to.include(attribute)
+    : expect(elementAttribute).to.include(attribute)
 });
 
 /* ---- contains / equal the value ---- */
@@ -130,18 +100,20 @@ Then(/^the "([^"]*)" input should equal the value "([^"]*)"$/, async (elementNam
   expect(elementAttribute).to.equals(elementValue);
 });
 
-Then(/^the "([^"]*)" contains the value "([^"]*)"$/, async (elementName: string, elementValue: string) => {
+Then(/^the "([^"]*)" input contains the value "([^"]*)"$/, async (elementName: string, elementValue: string) => {
   const element: ElementFinder = await elementHelper().getElementByCss(elementName);
   const elementAttribute = await htmlHelper().getAttribute(element, 'value');
   expect(elementAttribute).to.include(elementValue);
 });
 
 /* verify the attribute value of an element within another element */
-Then(/^the "([^"]*)" element within the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" element contains the "([^"]*)" attribute "([^"]*)"$/, async (subelement: string, parentElementIndex: string, mainElementName: string, attributeType: string, attribute: string) => {
+Then(/^the "([^"]*)" element within the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" element (does not )?contains? the "([^"]*)" attribute "([^"]*)"$/, async (subelement: string, parentElementIndex: string, mainElementName: string, negate: string, attributeType: string, attribute: string) => {
   const index = parseInt(parentElementIndex, 10) - 1;
   let element = await elementHelper().getElementInElementByCss(mainElementName, subelement, 0,true,index);
   const elementAttribute = await htmlHelper().getAttribute(element, attributeType);
-  expect(elementAttribute).to.include(attribute);
+  negate
+      ? expect(elementAttribute).not.to.include(attribute)
+      : expect(elementAttribute).to.include(attribute);
 });
 
 Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (?:option|element|input) contains the text "([^"]*)"$/, async (elementPosition: string, elementName: string, expectedElementText: string) => {

--- a/src/e2e/step-definitions/then/verify-element-value.ts
+++ b/src/e2e/step-definitions/then/verify-element-value.ts
@@ -18,34 +18,23 @@ Then(/^the "([^"]*)" contains no text$/, async (elementName: string) => {
   expect(elementText).equals('');
 });
 
-Then(/^the "([^"]*)" does not contain the text "([^"]*)"$/, async (elementName: string, expectedElementText: string) => {
+Then(/^the "([^"]*)" (does not )?contains? the text "([^"]*)"$/, async (elementName: string, negate: string, expectedElementText: string) => {
   const element: ElementFinder = await elementHelper().getElementByCss(elementName);
   const elementText = await htmlHelper().getElementText(element);
   const currentElementText = stringManipulationHelper().replaceLineBreaks(elementText);
-  expect(currentElementText).to.not.include(expectedElementText);
+  negate
+      ? expect(currentElementText).to.not.include(expectedElementText)
+      : expect(currentElementText).to.include(expectedElementText);
 });
 
-Then(/^the "([^"]*)" contains the text "([^"]*)"$/, async (elementName: string, expectedElementText: string) => {
-  const element: ElementFinder = await elementHelper().getElementByCss(elementName);
-  const elementText = await htmlHelper().getElementText(element);
-  const currentElementText = stringManipulationHelper().replaceLineBreaks(elementText);
-  expect(currentElementText).to.include(expectedElementText);
-});
-
-Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the text "([^"]*)"$/, async (elementPosition: string, elementName: string, expectedElementText: string) => {
-  let index: number = parseInt(elementPosition.replace(/^\D+/g, ''), 10) - 1;
-  const element: ElementFinder =  await elementHelper().getElementByCss(elementName, index);
-  const elementText = await htmlHelper().getElementText(element);
-  const currentElementText = stringManipulationHelper().replaceLineBreaks(elementText);
-  expect(currentElementText).to.include(expectedElementText);
-});
-
-Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the text "([^"]*)"$/, async (elementIndex: string, elementName: string, expectedElementText: string) => {
+Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the text "([^"]*)"$/, async (elementIndex: string, elementName: string, negate: string, expectedElementText: string) => {
   let index: number = parseInt(elementIndex.replace(/^\D+/g, ''), 10) - 1;
   const element: ElementFinder =  await elementHelper().getElementByCss(elementName, index);
   const elementText = await htmlHelper().getElementText(element);
   const currentElementText = stringManipulationHelper().replaceLineBreaks(elementText);
-  expect(currentElementText).to.not.include(expectedElementText);
+  negate
+      ? expect(currentElementText).to.not.include(expectedElementText)
+      : expect(currentElementText).to.include(expectedElementText);
 });
 
 Then(/^the "([^"]*)" for specific "([^"]*)" (does not )?contains? the text "([^"]*)"$/, async (elementName: string, selectorModifiers: string, negate: string, expectedElementText: string) => {


### PR DESCRIPTION
Combined Steps: negate!

Covers all existiong steps (e2e/README.md)

Two steps (appeared to be working) now actually working and combined: negate!

Then the "([^"]*)" does not contain the text "([^"]*)"
Then the "([^"]*)" contains the text "([^"]*)"

Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the text "([^"]*)"
Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the text "([^"]*)"

Then the "([^"]*)" contains the "([^"]*)" text "([^"]*)
Then the "([^"]*)" does not contain the "([^"]*)" text "([^"]*)"

Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the "([^"]*)" text "([^"]*)"
Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" text "([^"]*)"

Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the "([^"]*)" attribute "([^"]*)"
Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" attribute "([^"]*)"

Automation: verify-element-value.feature

Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"