### PR TITLE
automate-verify-element-value-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ npm run clean
 - Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute
 - Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
 - Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
-- Then the "([^"]*)" input should equal the value "([^"]*)"
-- Then the "([^"]*)" contains the value "([^"]*)"
+- Then the "([^"]*)" should equal the value "([^"]*)"
+- Then the "([^"]*)" (does not )?contains? the value "([^"]*)"
 - Then the "([^"]*)" element within the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" element (does not )?contains? the "([^"]*)" attribute "([^"]*)"
 - Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (?:option|element|input|dropdown) contains the text "([^"]*)"
 - Then the last "([^"]*)" (?:option|element|input|dropdown) contains the text "([^"]*)"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -71,8 +71,8 @@
 - [x] Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute
 - [x] Then the "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
 - [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" attribute "([^"]*)"
-- [x] Then the "([^"]*)" input should equal the value "([^"]*)"
-- [x] Then the "([^"]*)" contains the value "([^"]*)"
+- [x] Then the "([^"]*)" (does not )?equals? the value "([^"]*)"
+- [x] Then the "([^"]*)" (does not )?contains? the value "([^"]*)"
 - [x] Then the "([^"]*)" element within the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" element (does not )?contains? the "([^"]*)" attribute "([^"]*)"
 - [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (?:option|element|input|dropdown) contains the text "([^"]*)"
 - [x] Then the last "([^"]*)" (?:option|element|input|dropdown) contains the text "([^"]*)"

--- a/e2e/features/verify-element-value.feature
+++ b/e2e/features/verify-element-value.feature
@@ -57,21 +57,23 @@ Feature: As an automation framework I can verify element value
 
     @desktop
     @smoke
-    Scenario: As a automation framework I can verify an input has the exact text
+    Scenario: As a automation framework I can verify an element has the exact value
       Given I am on the "home" page
         And I fill in the "search" input with "Louis XVI"
-      Then the "search" input should equal the value "Louis XVI"
+      Then the "search" equals the value "Louis XVI"
+        And the "search" does not equal the value "LOUIS XXVI"
 
     @desktop
     @smoke
-    Scenario: As a automation framework I can verify an input contains the text
+    Scenario: As a automation framework I can verify an element contains the value
       Given I am on the "home" page
         And I fill in the "search" input with "Louis XVI"
-      Then the "search" input contains the value "XVI"
+      Then the "search" contains the value "XVI"
+        And the "search" does not contain the value "XXVI"
 
     @desktop
     @smoke
-    Scenario: As a automation framework I can verify an input has the exact text
+    Scenario: As a automation framework I can verify an element within an element contains the attribute and does not contain the attribute
       Given I am on the "home" page
         And the "edit" element within the "3rd" "contact item" element contains the "name" attribute "edit"
       Then the "edit" element within the "3rd" "contact item" element does not contain the "name" attribute "delete"
@@ -95,7 +97,7 @@ Feature: As an automation framework I can verify element value
 
     @desktop
     @smoke
-    Scenario: As a automation framework I can how many options a select contains
+    Scenario: As a automation framework I can count how many options a select contains
       Given I am on the "home" page
         And I click the "add" button
       When I am directed to the "add record" page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabcorp-cucumber-protractor-framework-v2",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "common cucumber steps written with protractor",
   "main": "dist/index.js",
   "typings": "dist/index",

--- a/src/e2e/step-definitions/then/verify-element-value.ts
+++ b/src/e2e/step-definitions/then/verify-element-value.ts
@@ -82,20 +82,22 @@ Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)
     : expect(elementAttribute).to.include(attribute)
 });
 
-/* ---- contains / equal the value ---- */
-Then(/^the "([^"]*)" input should equal the value "([^"]*)"$/, async (elementName: string, elementValue: string) => {
+Then(/^the "([^"]*)" (does not )?equals? the value "([^"]*)"$/, async (elementName: string,  negate: string, elementValue: string) => {
   const element: ElementFinder = await elementHelper().getElementByCss(elementName);
   const elementAttribute = await htmlHelper().getAttribute(element, 'value');
-  expect(elementAttribute).to.equals(elementValue);
+  negate
+    ? expect(elementAttribute).not.to.equals(elementValue)
+    : expect(elementAttribute).to.equals(elementValue);
 });
 
-Then(/^the "([^"]*)" input contains the value "([^"]*)"$/, async (elementName: string, elementValue: string) => {
+Then(/^the "([^"]*)" (does not )?contains? the value "([^"]*)"$/, async (elementName: string, negate: string, elementValue: string) => {
   const element: ElementFinder = await elementHelper().getElementByCss(elementName);
   const elementAttribute = await htmlHelper().getAttribute(element, 'value');
-  expect(elementAttribute).to.include(elementValue);
+  negate
+    ? expect(elementAttribute).not.to.include(elementValue)
+    : expect(elementAttribute).to.include(elementValue);
 });
 
-/* verify the attribute value of an element within another element */
 Then(/^the "([^"]*)" element within the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" element (does not )?contains? the "([^"]*)" attribute "([^"]*)"$/, async (subelement: string, parentElementIndex: string, mainElementName: string, negate: string, attributeType: string, attribute: string) => {
   const index = parseInt(parentElementIndex, 10) - 1;
   let element = await elementHelper().getElementInElementByCss(mainElementName, subelement, 0,true,index);


### PR DESCRIPTION
Further improvements to verify-element-value steps.

Also reverted value steps to not contain "input" reference. 