### PR TITLE
automation-element-presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,11 @@ npm run clean
 
 ##### verify-element-presence
 
-- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" element
-- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" does not contain the "([^"]*)" element
-- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" for specific "([^"]*)" element
-- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" does not contain the "([^"]*)" for specific "([^"]*) element
-- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the "([^"]*)" element
+- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" element
+- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" element
+- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" for specific "([^"]*)" element
+- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" for specific "([^"]*)" element
 - Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains "([0-9]+)" "([^"]*)" (?:element|elements)
-- Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains "([^"]*)" "([^"]*)"
 - Then the "([^"]*)" containing the text "([^"]*)" has a "([^"]*)" element
 - Then the "([^"]*)" (?:button|link|icon|element) should( not)? be present
 - Then the "([^"]*)" for specific "([^"]*)" (?:button|link|icon|element) should( not)? be present

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -8,18 +8,16 @@
 
 ##### verify-element-presence
 
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" element
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" does not contain the "([^"]*)" element
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" for specific "([^"]*)" element
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" does not contain the "([^"]*)" for specific "([^"]*) element
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the "([^"]*)" element
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains "([0-9]+)" "([^"]*)" (?:element|elements)
-- [ ] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains "([^"]*)" "([^"]*)"
-- [ ] Then the "([^"]*)" containing the text "([^"]*)" has a "([^"]*)" element
-- [ ] Then the "([^"]*)" (?:button|link|icon|element) should( not)? be present
-- [ ] Then the "([^"]*)" for specific "([^"]*)" (?:button|link|icon|element) should( not)? be present
-- [ ] Then the "([0-9]+th|[0-9]+st|[0-9]+nd|[0-9]+rd)" "([^"]*)" element should( not)? be present
-- [ ] Then the "([^"]*)" element within the "([^"]*)" should( not)? be present
+- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" element
+- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" element
+- [x] hen the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" for specific "([^"]*)" element
+- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" for specific "([^"]*)" element
+- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains "([0-9]+)" "([^"]*)" (?:element|elements)
+- [x] Then the "([^"]*)" containing the text "([^"]*)" has a "([^"]*)" element
+- [x] Then the "([^"]*)" (?:button|link|icon|element) should( not)? be present
+- [x] Then the "([^"]*)" for specific "([^"]*)" (?:button|link|icon|element) should( not)? be present
+- [x] Then the "([0-9]+th|[0-9]+st|[0-9]+nd|[0-9]+rd)" "([^"]*)" element should( not)? be present
+- [x] Then the "([^"]*)" element within the "([^"]*)" should( not)? be present
 
 ##### verify-element-status
 

--- a/e2e/features/verify-element-presence.feature
+++ b/e2e/features/verify-element-presence.feature
@@ -1,0 +1,79 @@
+Feature: As an automation framework I can verify element presence
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an element contains an element and does not contain an element
+      Given I am on the "home" page
+          And the "contacts header" contains the text "Contacts"
+      Then the "contacts header" does not contain the text "French Revolution"
+        And the "1st" "contact item" contains the "edit" element
+        And the "1st" "contact item" does not contain the "contacts header" element
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify a specific element contains an element and does not contain an element
+      Given I am on the "home" page
+        And the "1st" "contact" for specific "item" contains the "edit" element
+      Then the "1st" "contact" for specific "item" does not contain the "contacts header" element
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an element with a specific element does and and does not contain an element
+      Given I am on the "home" page
+        And the "1st" "contact item" contains the "full name" for specific "label" element
+      Then the "1st" "contact item" does not contain the "full name" for specific "checkbox" element
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify a specific element contains and does not contain a specific element
+      Given I am on the "home" page
+        And the "1st" "contact" for specific "item" contains the "full name" for specific "label" element
+      Then the "1st" "contact" for specific "item" does not contain the "full name" for specific "checkbox" element
+
+    @desktop
+    @smoke
+    Scenario: As a automation framework I can verify an email contains a count of an element
+      Given I am on the "home" page
+        And the "1st" "contact item" contains "1" "edit" element
+      Then the "1st" "contact item" contains "1" "edit" element
+
+    @desktop
+    @smoke
+    Scenario: As an automation framework I can an element containing the text contains the element
+      Given I am on the "home" page
+        And the "content" containing the text "Abraham Perry" has a "inner content" element
+
+    @desktop
+    @smoke
+    Scenario: As an automation framework I expect the element to be present
+      Given I am on the "home" page
+        And the "search" element should be present
+      And the "help" element should not be present
+
+    @desktop
+    @smoke
+    Scenario: As an automation framework I expect the element to be present
+      Given I am on the "home" page
+        And the "search" element should be present
+      And the "help" element should not be present
+
+    @desktop
+    @smoke
+    Scenario: As an automation framework I expect the specific element to be present and not to be present
+      Given I am on the "home" page
+        And the "contact" for specific "item" element should be present
+      Then the "full name" for specific "checkbox" element should not be present
+
+    @desktop
+    @smoke
+    Scenario: As an automation framework I expect an element at index to be present and not to be present
+      Given I am on the "home" page
+        And the "1st" "contact item" element should be present
+      Then the "2nd" "search" element should not be present
+
+    @desktop
+    @smoke
+    Scenario: As an automation framework I expect an element at index to be present and not to be present
+      Given I am on the "home" page
+        And the "edit" element within the "contact item" should be present
+      Then the "search" element within the "contact item" should not be present

--- a/e2e/features/verify-element-value.feature
+++ b/e2e/features/verify-element-value.feature
@@ -11,14 +11,14 @@ Feature: As an automation framework I can verify element value
     @smoke
     Scenario: As a automation framework I can verify an element at index contains and does not contain the text
       Given I am on the "home" page
-          And the "1st" "contact item" contains the text "Abraham Perry"
+          And the "1st" "contact item" contains the text "Vulputate Street"
       Then the "1st" "contact item" does not contain the text "Jacques Necker"
 
     @desktop
     @smoke
     Scenario: As a automation framework I can verify an element with dynamic element data id contains and does not contain the text
       Given I am on the "home" page
-          And the "contact" for specific "item" contains the text "Abraham Perry"
+          And the "contact" for specific "item" contains the text "Vulputate Street"
       Then the "contact" for specific "item" does not contain the text "Jacques Necker"
 
     @desktop

--- a/e2e/mappings/pages/home.json
+++ b/e2e/mappings/pages/home.json
@@ -1,19 +1,24 @@
 {
   "contacts header" : "contacts-header",
   "contact item" : "contact-item",
+  "help" : "help",
   "search" : "search",
+  "name label" : "name",
   "name" : "name",
   "phone" : "phone",
   "street" : "street",
   "submit" : "submit",
   "cancel" : "cancel",
   "city" : "city",
+  "content" : "content",
+  "inner content" : "inner-content",
   "edit button" : "edit",
   "add button" : "add",
   "hidden div" : "hidden-div",
   "hidden" : "hidden-",
   "delete button" : "delete",
   "contact" : "contact-",
+  "full name" : "full-name-",
   "hidden contact" : "hidden-contact-"
 }
 

--- a/e2e/support/custom-hooks/v2-hook.ts
+++ b/e2e/support/custom-hooks/v2-hook.ts
@@ -33,9 +33,6 @@ BeforeAll(async function () {
 Before(async function (scenario) {
   const requiredConfig: IRequiredConfig = new RequiredConfig(browser.params.requiredConfig);
   setupForAngularApp(requiredConfig.isAngularApp);
-  //const current_scenario = scenario;
-  //console.log(current_scenario);
-  //await setupBrowserResolution(current_scenario);
 });
 
 After(async function (scenario) {

--- a/e2e/support/framework-helpers/implementations/custom/v2-framework/custom-navigation-behavior-helper.ts
+++ b/e2e/support/framework-helpers/implementations/custom/v2-framework/custom-navigation-behavior-helper.ts
@@ -23,13 +23,11 @@ export class FormCustomNavigationBehavior implements ICustomNavigationBehaviorHe
   }
 
   public async urls(): Promise<{ [pageUrl:string]: string }> {
-    //console.log("form");
 
     if (this._urls == null) {
       this._urls = await this.loadUrlMap();
     }
 
-    //console.log("_urls ", this._urls);
     return this._urls;
   }
 

--- a/e2e/support/framework-helpers/implementations/custom/v2-framework/web-element-loader.ts
+++ b/e2e/support/framework-helpers/implementations/custom/v2-framework/web-element-loader.ts
@@ -27,24 +27,17 @@ export class FormWebElementLoader implements IWebElementLoader {
 
   public async getElementLocator(elementName: string, params: string[] = [], elementsMap?: { [PageWithElementName: string]: FormElement}): Promise<string> {
     const currentPage: string = this.navigationHelper.getCurrentPage();
-
-//     console.log('### element name:', elementName);
     let elementKey = this.generateElementKey(currentPage, elementName);
-//     console.log('### element key:', elementKey);
-//     console.log('### map:', this._elementsMap);
-//     console.log('### local map ', elementsMap)
     const theMap = (elementsMap || this._elementsMap);
     let elementSelector: string = theMap && theMap[elementKey] && theMap[elementKey].dataId;
 
     //Check by page
-//     console.log("1>> ", elementSelector)
     if (elementSelector == null) {
       this.loadElementMap(currentPage);
       elementSelector = (this._elementsMap[elementKey] || {} as any).dataId
     }
 
     //Not in current page check common
-//     console.log("2>> ", elementSelector)
     if (elementSelector == null) {
       elementKey = this.generateElementKey('common', elementName);
       this.loadElementMap('common');
@@ -52,7 +45,6 @@ export class FormWebElementLoader implements IWebElementLoader {
     }
 
     //finally check by passed in
-//     console.log("3>> ", elementSelector)
     if (elementSelector == null) {
       elementSelector = elementName;
     }
@@ -61,6 +53,8 @@ export class FormWebElementLoader implements IWebElementLoader {
   }
 
   private generateDataTestId(genericTestId: string, params: string[]) {
+
+
       let testId: string = genericTestId;
       if (params != null) {
         for (const value of params) {
@@ -97,7 +91,6 @@ export class FormWebElementLoader implements IWebElementLoader {
   }
 
   private generateElementKey(pageId: string, key: string) {
-    //console.log("generateElementKey ", '[data-id='+(pageId + key).toLocaleLowerCase()+']');
     return (pageId + key).toLocaleLowerCase();
   }
 

--- a/e2e/support/steps-helpers/custom/v2-framework/jurisdiction-helper.ts
+++ b/e2e/support/steps-helpers/custom/v2-framework/jurisdiction-helper.ts
@@ -46,7 +46,6 @@ export class FormJurisdictionHelper implements IJurisdictionHelper {
     const currentPage: string = this.customeNavigationBehaviorHelper.getCurrentPage();
     const currentURL = await this.customeNavigationBehaviorHelper.generateUrl(currentPage);
     const currentURLWithJurisdiction = currentURL + "?jurisdiction=" + jurisdiction;
-    //console.log(currentURLWithJurisdiction);
     await this.pageHelper.navigateToUrl(currentURLWithJurisdiction);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabcorp-cucumber-protractor-framework-v2",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "common cucumber steps written with protractor",
   "main": "dist/index.js",
   "typings": "dist/index",

--- a/src/e2e/step-definitions/then/verify-element-presence.ts
+++ b/src/e2e/step-definitions/then/verify-element-presence.ts
@@ -9,39 +9,36 @@ import { BASETYPES } from '../../IoC/base-types';
 const elementHelper = (): WebElementHelper => RegistrationIoC.getContainer().get<WebElementHelper>(BASETYPES.WebElementHelper);
 const htmlHelper = (): HtmlHelper => RegistrationIoC.getContainer().get<HtmlHelper>(BASETYPES.HtmlHelper);
 
-/* ---- does not contain the "" element / constains the "" element/ constains "X" "" (elements) ---- */
-Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" element$/, async (mainElementPosition: string, mainElementName: string, subElementName: string) => {
+Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" element$/, async (mainElementPosition: string, mainElementName: string, negate: string, subElementName: string) => {
   const index: number = parseInt(mainElementPosition.replace(/^\D+/g, ''), 10) - 1;
-  const elements: ElementFinder[] = await elementHelper().getAllElementsInElementByCss(mainElementName, subElementName, index, false);
-  expect(elements.length).to.equal(0);
+  const element: ElementFinder = await elementHelper().getElementInElementByCss(mainElementName, subElementName, index);
+  const isPresent: boolean = await htmlHelper().isElementPresent(element);
+  expect(isPresent).to.equal(!negate);
 });
 
-Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" does not contain the "([^"]*)" element$/, async (mainElementPosition: string, mainElementName: string, mainElementSelectorModifiers: string, subElementName: string) => {
+Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" element$/, async (mainElementPosition: string, mainElementName: string, mainElementSelectorModifiers: string, negate: string, subElementName: string) => {
   const mainParams: string[] = mainElementSelectorModifiers.split(',');
   const index: number = parseInt(mainElementPosition.replace(/^\D+/g, ''), 10) - 1;
-  const elements: ElementFinder[] = await elementHelper().getAllElementsInElementByCss(mainElementName, subElementName, index, false, mainParams);
-  expect(elements.length).to.equal(0);
+  const element: ElementFinder = await elementHelper().getElementInElementByCss(mainElementName, subElementName, 0, true, index, mainParams);
+  const isPresent: boolean = await htmlHelper().isElementPresent(element);
+  expect(isPresent).to.equal(!negate);
 });
 
-Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" does not contain the "([^"]*)" for specific "([^"]*)" element$/, async (mainElementPosition: string, mainElementName: string, subElementName: string, subElementSelectorModifiers: string) => {
+Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" for specific "([^"]*)" element$/, async (mainElementPosition: string, mainElementName: string, negate: string, subElementName: string, subElementSelectorModifiers: string) => {
   const subParams: string[] = subElementSelectorModifiers.split(',');
   const index: number = parseInt(mainElementPosition.replace(/^\D+/g, ''), 10) - 1;
-  const elements: ElementFinder[] = await elementHelper().getAllElementsInElementByCss(mainElementName, subElementName, index, false, null, subParams);
-  expect(elements.length).to.equal(0);
+  const element: ElementFinder = await elementHelper().getElementInElementByCss(mainElementName, subElementName, 0, true, index, null, subParams);
+  const isPresent: boolean = await htmlHelper().isElementPresent(element);
+  expect(isPresent).to.equal(!negate);
 });
 
-Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" does not contain the "([^"]*)" for specific "([^"]*) element$/, async (mainElementPosition: string, mainElementName: string, mainElementSelectorModifiers: string, subElementName: string, subElementSelectorModifiers: string) => {
-  const subParams: string[] = subElementSelectorModifiers.split(',');
+Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" for specific "([^"]*)" element$/, async (mainElementPosition: string, mainElementName: string, mainElementSelectorModifiers: string, negate: string, subElementName: string, subElementSelectorModifiers: string) => {
   const mainParams: string[] = mainElementSelectorModifiers.split(',');
+  const subParams: string[] = subElementSelectorModifiers.split(',');
   const index: number = parseInt(mainElementPosition.replace(/^\D+/g, ''), 10) - 1;
-  const elements: ElementFinder[] = await elementHelper().getAllElementsInElementByCss(mainElementName, subElementName, index, false, mainParams, subParams);
-  expect(elements.length).to.equal(0);
-});
-
-Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains the "([^"]*)" element$/, async (mainElementPosition: string, mainElementName: string, subElementName: string) => {
-  const index: number = parseInt(mainElementPosition.replace(/^\D+/g, ''), 10) - 1;
-  const elements: ElementFinder[] = await elementHelper().getAllElementsInElementByCss(mainElementName, subElementName, index);
-  expect(elements.length).to.gt(0);
+  const element: ElementFinder = await elementHelper().getElementInElementByCss(mainElementName, subElementName, 0, true, index, mainParams, subParams);
+  const isPresent: boolean = await htmlHelper().isElementPresent(element);
+  expect(isPresent).to.equal(!negate);
 });
 
 Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains "([0-9]+)" "([^"]*)" (?:element|elements)$/, async (mainElementPosition: string, mainElementName: string, expectedCount: string, subElementName: string) => {
@@ -50,16 +47,11 @@ Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains "([0-9]+)" "([^"]*)" (?:e
   expect(elements.length).to.equal(parseInt(expectedCount));
 });
 
-Then(/^the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains "([^"]*)" "([^"]*)"$/, async (mainElementPosition: string, mainElementName: string, expectedSubElementsCount: number, subElementName: string) => {
-  let index: number = parseInt(mainElementPosition.replace(/^\D+/g, ''), 10) - 1;
-  const elements: ElementFinder[] = await elementHelper().getAllElementsInElementByCss(mainElementName, subElementName, index);
-  expect(elements.length).to.equals(expectedSubElementsCount);
-});
-
 Then(/^the "([^"]*)" containing the text "([^"]*)" has a "([^"]*)" element$/, async (mainElementName: string, mainElementText: string, subElementName: string) => {
   const mainElement = await elementHelper().getElementByCssContainingText(mainElementName, mainElementText);
-  const elements: ElementFinder[] = await elementHelper().getAllElementsInWebElementByCss(mainElement, subElementName);
-  expect(elements.length).to.be.gt(0, 'No elements were found');
+  const element: ElementFinder = await elementHelper().getElementInWebElementByCss(mainElement, subElementName);
+  const isPresent: boolean = await htmlHelper().isElementPresent(element);
+  expect(isPresent).to.equal(true);
 });
 
 /* ---- should be present / should not be present ---- */

--- a/src/e2e/support/framework-helpers/implementations/web-element-helper.ts
+++ b/src/e2e/support/framework-helpers/implementations/web-element-helper.ts
@@ -25,15 +25,16 @@ export class WebElementHelper {
 
   public async getElementByCss(elementName: string, index: number = 0, expectPresence: boolean = true, nameParams: string[] = [])
     : Promise<ElementFinder> {
+
     let list = await this.getAllElementsByCss(elementName, expectPresence, nameParams);
     return this.getNthElementInList(list, index);
   }
 
   public async getAllElementsByCss(elementName: string, expectPresence: boolean = true, nameParams: string[] = [])
     : Promise<ElementFinder[]> {
+
     const elementLocator: string = await this.webElementLoader.getElementLocator(elementName, nameParams);
     const locatorSelector: Locator = by.css(elementLocator);
-
     let elements = await this.retrieveElements(locatorSelector, expectPresence);
 
     return elements;
@@ -46,6 +47,7 @@ export class WebElementHelper {
   }
   public async getAllElementsByCssContainingText(elementName: string, elementText: string, expectPresence: boolean = true, nameParams: string[] = [])
     : Promise<ElementFinder[]> {
+
     const elementLocator: string = await this.webElementLoader.getElementLocator(elementName, nameParams);
     const locatorSelector: ProtractorLocator = by.cssContainingText(elementLocator, elementText);
 
@@ -57,18 +59,18 @@ export class WebElementHelper {
   public async getElementInElementByCss(parentElementName: string, elementName: string, index: number = 0, expectPresence: boolean = true,
     parentElementIndex: number = 0, parentNameParams: string[] = [], nameParams: string[] = [])
     : Promise<ElementFinder> {
+
       let list = await this.getAllElementsInElementByCss(parentElementName, elementName, parentElementIndex, expectPresence, parentNameParams, nameParams);
       return this.getNthElementInList(list, index);
   }
   public async getAllElementsInElementByCss(parentElementName: string, elementName: string, parentElementIndex: number = 0,
     expectPresence: boolean = true, parentNameParams: string[] = [], nameParams: string[] = [])
     : Promise<ElementFinder[]> {
-    let parentElement: ElementFinder = await this.getElementByCss(parentElementName, parentElementIndex, true, parentNameParams);
 
+    let parentElement: ElementFinder = await this.getElementByCss(parentElementName, parentElementIndex, true, parentNameParams);
     const elementLocator: string = await this.webElementLoader.getElementLocator(elementName, nameParams);
     const locatorSelector: Locator = by.css(elementLocator);
     let elements = await this.retrieveElements(locatorSelector, expectPresence, parentElement);
-
     return elements;
   }
 
@@ -130,6 +132,7 @@ export class WebElementHelper {
   }
 
   private getNthElementInList(elementList: ElementFinder[], index: number) {
+
     const webElement: ElementFinder = elementList && elementList.length > index
                                     ? elementList[index]
                                     : element(by.id(`[NOT-FOUND] [index=${index}] [element=${elementList}]`));


### PR DESCRIPTION
Automated all the element-presence steps:

Fixed a bunch of steps that appeared to be working but were not..

- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" element
- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" element
- [x] hen the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" (does not )?contains? the "([^"]*)" for specific "([^"]*)" element
- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" for specific "([^"]*)" (does not )?contains? the "([^"]*)" for specific "([^"]*)" element
- [x] Then the "(1st|2nd|3rd|[0-9]+th)" "([^"]*)" contains "([0-9]+)" "([^"]*)" (?:element|elements)
- [x] Then the "([^"]*)" containing the text "([^"]*)" has a "([^"]*)" element
- [x] Then the "([^"]*)" (?:button|link|icon|element) should( not)? be present
- [x] Then the "([^"]*)" for specific "([^"]*)" (?:button|link|icon|element) should( not)? be present
- [x] Then the "([0-9]+th|[0-9]+st|[0-9]+nd|[0-9]+rd)" "([^"]*)" element should( not)? be present
- [x] Then the "([^"]*)" element within the "([^"]*)" should( not)? be present